### PR TITLE
Fix product page display in landscape mode

### DIFF
--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Parade",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "images": [
     {
       "variable": "logo",

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -129,7 +129,8 @@
   visibility: hidden
 
 .product-page-content
-  left: 0
+  +transform(translateX(-50%))
+  left: 50%
   min-height: calc(100vh - 100px)
   padding: 0 50px
   position: absolute
@@ -137,8 +138,17 @@
   width: 100%
 
   @media screen and (max-width: $break-medium)
+    margin-top: 60px
+
+  @media screen and (max-width: $break-small)
+    +transform(none)
     position: relative
     top: auto
+    left: 0
+    margin-top: 100vh
+
+  @media screen and (max-width: $break-medium) and (orientation: portrait)
+    margin-top: 0
 
 .product-page-button
   display: block


### PR DESCRIPTION
Fixes an issue with smaller screens in landscape mode - the product page images were overlapping the product page form / description.